### PR TITLE
don't add pointless newline between comments

### DIFF
--- a/src/main/java/io/github/thatsmusic99/configurationmaster/CMFile.java
+++ b/src/main/java/io/github/thatsmusic99/configurationmaster/CMFile.java
@@ -563,7 +563,7 @@ public abstract class CMFile {
         if (!pendingComments.isEmpty()) {
             StringBuilder builder = new StringBuilder();
             for (String str : pendingComments) {
-                builder.append(str).append("\n\n");
+                builder.append(str).append("\n");
             }
             pendingComments.clear();
             comments.put(path, builder.toString());


### PR DESCRIPTION
This makes it so user can decide when to put newline by adding empty `addComment("");` instead of getting

spaced

out

comments

 like this